### PR TITLE
Fix compiling Python bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ TARGET_COMPILE_OPTIONS(hpdbscan-bin PRIVATE ${OpenMP_CXX_FLAGS})
 
 ## hdf5
 FIND_PACKAGE(HDF5 1.8.10 REQUIRED)
-INCLUDE_DIRECTORIES("${HDF5_INCLUDE_DIRS}")
+TARGET_INCLUDE_DIRECTORIES(hpdbscan-bin PRIVATE "${HDF5_INCLUDE_DIRS}")
 TARGET_LINK_LIBRARIES(hpdbscan-bin PRIVATE "${HDF5_LIBRARIES}")
 
 ## swig and python detection for optional bindings
@@ -57,7 +57,6 @@ IF(SWIG_FOUND)
             MESSAGE("PYTHON HEADERS NOT FOUND, BUILDING WITHOUT BINDINGS")
             MESSAGE("TRY INSTALLING THE python-dev OR python-devel PACKAGE")
         ELSE()
-            INCLUDE_DIRECTORIES(${PYTHON_INCLUDE_DIRS})
 	    FIND_PACKAGE(NumPy)
 	    IF(NUMPY_FOUND)
 		EXECUTE_PROCESS(COMMAND swig -c++ -python -I"${PYTHON_INCLUDE_DIRS}" -I"${NUMPY_INCLUDE_DIRS}" -o "${CMAKE_CURRENT_BINARY_DIR}/hpdbscan_wrap.cpp" "${CMAKE_CURRENT_SOURCE_DIR}/swig/hpdbscan.i")
@@ -71,8 +70,10 @@ IF(SWIG_FOUND)
                         MESSAGE("MPI FOUND, BUT MPI4PY MISSING, BINDING WILL BE BUILT WITHOUT MPI SUPPORT")
                     ENDIF()
                 ENDIF()
+		TARGET_INCLUDE_DIRECTORIES(hpdbscan-binding PRIVATE ${PYTHON_INCLUDE_DIRS} ${NUMPY_INCLUDE_DIRS})
                 TARGET_LINK_LIBRARIES(hpdbscan-binding PRIVATE ${OpenMP_CXX_FLAGS})
                 TARGET_COMPILE_OPTIONS(hpdbscan-binding PRIVATE ${OpenMP_CXX_FLAGS})
+		TARGET_INCLUDE_DIRECTORIES(hpdbscan-binding PRIVATE "${HDF5_INCLUDE_DIRS}")
                 TARGET_LINK_LIBRARIES(hpdbscan-binding PRIVATE "${HDF5_LIBRARIES}")
                 
                 # rename the library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,10 +70,10 @@ IF(SWIG_FOUND)
                         MESSAGE("MPI FOUND, BUT MPI4PY MISSING, BINDING WILL BE BUILT WITHOUT MPI SUPPORT")
                     ENDIF()
                 ENDIF()
-		TARGET_INCLUDE_DIRECTORIES(hpdbscan-binding PRIVATE ${PYTHON_INCLUDE_DIRS} ${NUMPY_INCLUDE_DIRS})
+                TARGET_INCLUDE_DIRECTORIES(hpdbscan-binding PRIVATE ${PYTHON_INCLUDE_DIRS} ${NUMPY_INCLUDE_DIRS})
                 TARGET_LINK_LIBRARIES(hpdbscan-binding PRIVATE ${OpenMP_CXX_FLAGS})
                 TARGET_COMPILE_OPTIONS(hpdbscan-binding PRIVATE ${OpenMP_CXX_FLAGS})
-		TARGET_INCLUDE_DIRECTORIES(hpdbscan-binding PRIVATE "${HDF5_INCLUDE_DIRS}")
+                TARGET_INCLUDE_DIRECTORIES(hpdbscan-binding PRIVATE "${HDF5_INCLUDE_DIRS}")
                 TARGET_LINK_LIBRARIES(hpdbscan-binding PRIVATE "${HDF5_LIBRARIES}")
                 
                 # rename the library


### PR DESCRIPTION
When compiling the Python bindings it needs the path to the numpy headers or it will fail with:

```
hpdbscan_wrap.cpp:3344:10: Fatal error: numpy/arrayobject.h: No such file or directory
 3344 | #include <numpy/arrayobject.h>
      |          ^~~~~~~~~~~~~~~~~~~~~
```

Also replace one call by its `TARGET_*` equivalent for consistency